### PR TITLE
Add filtering for incomplete sets when updating

### DIFF
--- a/mtgtools/util/api_requests.py
+++ b/mtgtools/util/api_requests.py
@@ -115,7 +115,9 @@ def process_mtgio_cards(sets, cards, verbose=True, workers=8):
 
 def process_scryfall_cards(sets, cards, verbose=True, workers=8):
     card_page_uris = []
-    for current_set in sets:
+
+    incomplete_sets = [_set for _set in sets if _set.card_count != len(_set.cards)]
+    for current_set in incomplete_sets:
         card_page_uris.extend([scryfall_card_search_url.format(page, current_set.code) for page in
                                range(1, int(math.ceil(current_set.card_count / 175)) + 1)])
 


### PR DESCRIPTION
Every call to `scryfall_update` was triggering each page for each set to be re-downloaded, resulting in roughly 750 requests.
By restricting the update to incomplete sets, the number of requests made can be cut down dramatically.

## Adds
- Filtering for incomplete sets before creating `card_page_uris` for `scryfall_update`